### PR TITLE
Don't upload log files to Git/npm package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /node_modules
+*.log


### PR DESCRIPTION
There's a Yarn error log uploaded on version 1.1.0

https://cdn.jsdelivr.net/npm/jest-environment-jsdom-global@1.1.0/