### PR TITLE
Publish with npm instead of yarn

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -28,7 +28,7 @@ jobs:
           node-version: 12
           registry-url: https://registry.npmjs.org/
       - run: yarn --frozen-lockfile
-      - run: yarn publish
+      - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}
 
@@ -42,6 +42,6 @@ jobs:
           node-version: 12
           registry-url: https://npm.pkg.github.com/
       - run: yarn --frozen-lockfile
-      - run: yarn publish
+      - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,7 @@
 __tests__/
+.github/
 .vscode/
 .prettierrc
+.yarnrc
 yarn.lock
+yarn-error.log


### PR DESCRIPTION
Publishing to GitHub Package Registry with Yarn doesn't seem to work well. Giving it a try with npm. (This is strictly a vanity exercise; I just want to kick the tires on GPR.)
