### PR TITLE
docs: Add a version disclaimer for JSDOM 16

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ describe("test suite", () => {
 });
 ```
 
-## Using JSDOM 16
+## Using JSDOM 16 (Jest 25 and lower)
+
+> NOTE: Jest 26 uses JSDOM 16 out of the box. These instructions only apply for versions of Jest < 26.0.0.
 
 If you want to swap `jest-environment-jsdom` for `jest-environment-jsdom-sixteen`, simply install it.
 


### PR DESCRIPTION
Jest 26 uses JSDOM 16 out of the box. I've updated the docs to reflect this; the functionality to use
jest-environment-jsdom-sixteen remains for users of earlier versions of Jest.