### PR TITLE
v3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-environment-jsdom-global",
-  "version": "2.0.4",
+  "version": "3.0.0",
   "main": "environment.js",
   "author": "Simon Andrews <me@simonandrews.ca>",
   "license": "MIT",


### PR DESCRIPTION
## Breaking changes:
* Node >= 12 is now required. Node 10 is out of mainstream support, so I've dropped support here, too
* `jest-environment-jsdom-sixteen` is no longer supported. Jest > 26 includes support out of the box. If you require `jest-environment-jsdom-sixteen`, continue using the latest `v2.x` release of this package

## Minor changes:
* Adds Jest 27 to the peer dependency range

## Internal
* All dependencies have been updated to the latest versions
* The primary branch has been renamed from `master` to `main`