### PR TITLE
docs: Add a note about @jest-environment-options

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 For more information, see [this discussion](https://github.com/facebook/jest/issues/5124) in the Jest repository.
 
+Before installing, please check if you need this package, particularly in light of [changes in Jest 28](#jest-28-update-is-this-package-still-useful).
+
 ## Installation and configuration
 
 Install the package with `yarn`:
@@ -44,11 +46,28 @@ describe("test suite", () => {
 
 ## Frequently Asked Questions
 
+### Jest 28 update: is this package still useful?
+
+[As of Jest 28](https://jestjs.io/blog/2022/04/25/jest-28#inline-testenvironmentoptions) ([formal docs](https://jestjs.io/docs/configuration#testenvironmentoptions-object)), you can provide options to JSDOM using inline comments in your tests. For example, to set the URL, you could write a test suite that looks like this:
+
+```
+/**
+ * @jest-environment jsdom
+ * @jest-environment-options {"url": "https://jestjs.io/"}
+ */
+
+test('use jsdom and set the URL in this test file', () => {
+  expect(window.location.href).toBe('https://jestjs.io/');
+});
+```
+
+This may solve for many previous use cases for this package, and I'd suggest using this approach rather than using `jest-environment-jsdom-global` if it suffices for your needs.
+
 ### Why can't I use `Object.defineProperty`?
 
 Jest's browser environment is based on JSDOM. JSDOM used to allow you to use `Object.defineProperty` to update certain properties on `window`; in particular, you could change parts of `window.location`, or `window.top`, as you need to.
 
-However, in recent versions, JSDOM's API has changed; the preferred way to mock `window.location` and its child properties is to use [`reconfigure`](https://github.com/tmpvar/jsdom#reconfiguring-the-jsdom-with-reconfiguresettings). JSDOM 11 became the default in Jest 22 (JSDOM 15 as of Jest 25); as a result, tests that used `Object.defineProperty` may no longer work on certain properties of `window`.
+However, several years ago, JSDOM's API changed; the preferred way to mock `window.location` and its child properties is to use [`reconfigure`](https://github.com/tmpvar/jsdom#reconfiguring-the-jsdom-with-reconfiguresettings). JSDOM 11 became the default back in Jest 22; as a result, tests that used `Object.defineProperty` may no longer work on certain properties of `window`.
 
 Currently, Jest does not expose the JSDOM `reconfigure` method inside test suites. The `jest-environment-jsdom-global` package is meant to solve this problem: it adds `jsdom` as a global, so you can reconfigure it within your tests.
 


### PR DESCRIPTION
The latest version of Jest supports configuring JSDOM per file. This may reduce the need for jest-environment-jsdom-global.