### PR TITLE
v3.1.1: More information on Jest 28

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-environment-jsdom-global",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "main": "environment.js",
   "author": "Simon Andrews <me@simonandrews.ca>",
   "license": "MIT",


### PR DESCRIPTION
An update to the README, explaining some changes in Jest 28 that may, in some cases, negate the need to use `jest-environment-jsdom-global`.