### PR TITLE
Make jest-environment-jsdom-global 100% compatible with jest v28

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -16,6 +16,9 @@ jobs:
     strategy:
       matrix:
         node-version: [12.x, 14.x, 16.x]
+        jest-version: [27.x, 28.x]
+
+    name: Tests - Node v${{ matrix.node-version }}, Jest v${{ matrix.jest-version }}
 
     steps:
       - uses: actions/checkout@v2
@@ -24,10 +27,5 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: yarn --frozen-lockfile
+      - run: yarn add jest@${{ matrix.jest-version }} jest-environment-jsdom@${{ matrix.jest-version }}
       - run: yarn test
-        env:
-          CI: true
-      - run: yarn add jest@27.x jest-environment-jsdom@27.x
-      - run: yarn test
-        env:
-          CI: true

--- a/__tests__/environment.test.js
+++ b/__tests__/environment.test.js
@@ -35,12 +35,12 @@ describe("using jest-environment-jsdom", () => {
   });
 
   test("should instantiate using jest-environment-jsdom", () => {
-    const environment = new jestEnvironmentJSDOMGlobal();
+    new jestEnvironmentJSDOMGlobal();
 
     expect(mockJestEnvironmentJsdom).toHaveBeenCalledTimes(1);
   });
 
-  test("should set jsdom on its global object", async () => {
+  test("should set jsdom on setup", async () => {
     const environment = new jestEnvironmentJSDOMGlobal();
 
     await environment.setup()

--- a/__tests__/environment.test.js
+++ b/__tests__/environment.test.js
@@ -13,6 +13,7 @@ const MockEnvironment = function () {
 
 const MockDefaultEnvironment = jest.fn(MockEnvironment);
 MockDefaultEnvironment.prototype.teardown = jest.fn();
+MockDefaultEnvironment.prototype.setup = jest.fn();
 
 describe("using jest-environment-jsdom", () => {
   let jestEnvironmentJSDOMGlobal;
@@ -39,8 +40,10 @@ describe("using jest-environment-jsdom", () => {
     expect(mockJestEnvironmentJsdom).toHaveBeenCalledTimes(1);
   });
 
-  test("should set jsdom on its global object", () => {
+  test("should set jsdom on its global object", async () => {
     const environment = new jestEnvironmentJSDOMGlobal();
+
+    await environment.setup()
 
     expect(environment.global.jsdom).toBe(mockDom);
   });
@@ -50,6 +53,6 @@ describe("using jest-environment-jsdom", () => {
 
     environment.teardown();
 
-    expect(environment.global.jsdom).toBe(null);
+    expect(environment.global.jsdom).toBe(undefined);
   });
 });

--- a/environment.js
+++ b/environment.js
@@ -6,15 +6,13 @@ if (pkg.default) {
 }
 
 module.exports = class JSDOMEnvironmentGlobal extends JSDOMEnvironment {
-  constructor(config, options) {
-    super(config, options);
-
+  async setup() {
+    await super.setup();
     this.global.jsdom = this.dom;
   }
 
-  teardown() {
-    this.global.jsdom = null;
-
-    return super.teardown();
+  async teardown() {
+    this.global.jsdom = undefined;
+    await super.teardown();
   }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-environment-jsdom-global",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "main": "environment.js",
   "author": "Simon Andrews <me@simonandrews.ca>",
   "license": "MIT",


### PR DESCRIPTION
Hi there! I'm a Software Engineer at Hotjar, and we are using this library in one of our projects. We have some advance scenarios where we need to change the URL dynamically in our tests, so the new jest url environment option is not enough for us.

We were using jest-environment-jsdom-global for this, but after upgrading jest to v28 we are getting weird errors from this dependency:

![TypeError: Cannot read properties of undefined (reading 'html')](https://user-images.githubusercontent.com/2677072/168858985-9bfd7394-56a8-4b1e-8a9f-a361655a3ab0.png)


I did some tweaks to your implementation in a local environment, which works fine, so I want to merge this in the package. In jest v28, it seems the constructor doesn't work as expected, so I've moved the init of jsdom to the setup hook instead.

I've also updated the CI config so tests are run against both jest v27 and v28.