### PR TITLE
v4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-environment-jsdom-global",
-  "version": "3.1.2",
+  "version": "4.0.0",
   "main": "environment.js",
   "author": "Simon Andrews <me@simonandrews.ca>",
   "license": "MIT",


### PR DESCRIPTION
Support for Jest 29, and end-of-support for Node 12.

- feat: Add Jest 29 support
- test: Replace Jest 28 with 29
- feat: Remove Node 12 support
- test: Add Node 18 support
- refactor: Run Prettier
